### PR TITLE
Make extension methods more DSL-ish

### DIFF
--- a/examples/form_companion_presenter_example/.gitignore
+++ b/examples/form_companion_presenter_example/.gitignore
@@ -31,6 +31,8 @@
 .pub/
 /build/
 
+coverage/
+
 # Web related
 lib/generated_plugin_registrant.dart
 

--- a/examples/form_companion_presenter_example/lib/auto_validation_form_builder_account.dart
+++ b/examples/form_companion_presenter_example/lib/auto_validation_form_builder_account.dart
@@ -203,14 +203,13 @@ class AutoValidationFormBuilderAccountPresenter extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             FormBuilderValidators.required,
             (context) => FormBuilderValidators.min(context, 0),
           ],
-          stringConverter: intStringConverter,
         )
         ..enumeratedList<Region>(
           name: 'preferredRegions',

--- a/examples/form_companion_presenter_example/lib/auto_validation_form_builder_account.dart
+++ b/examples/form_companion_presenter_example/lib/auto_validation_form_builder_account.dart
@@ -181,7 +181,7 @@ class AutoValidationFormBuilderAccountPresenter extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -192,18 +192,18 @@ class AutoValidationFormBuilderAccountPresenter extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             FormBuilderValidators.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
@@ -212,7 +212,7 @@ class AutoValidationFormBuilderAccountPresenter extends StateNotifier<Account>
           ],
           stringConverter: intStringConverter,
         )
-        ..addEnumList<Region>(
+        ..enumeratedList<Region>(
           name: 'preferredRegions',
           initialValues: initialState.preferredRegsions,
         ),

--- a/examples/form_companion_presenter_example/lib/auto_validation_form_builder_booking.dart
+++ b/examples/form_companion_presenter_example/lib/auto_validation_form_builder_booking.dart
@@ -244,23 +244,23 @@ class AutoValidationFormBuilderBookingPresenter extends StateNotifier<Booking>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addDateTimeRange(
+        ..dateTimeRange(
           name: 'stay',
           initialValue: initialState.stay,
         )
-        ..addDateTime(
+        ..dateTime(
           name: 'specialOfferDate',
           initialValue: initialState.specialOfferDate,
         )
-        ..addEnumWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
+        ..enumeratedWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
           name: 'roomType',
           initialValue: initialState.roomType,
         )
-        ..addEnumList<MealType>(
+        ..enumeratedList<MealType>(
           name: 'mealOffers',
           initialValues: initialState.mealOffers,
         )
-        ..addBool(
+        ..boolean(
           name: 'smoking',
           initialValue: initialState.smoking ?? false,
         )
@@ -269,17 +269,17 @@ class AutoValidationFormBuilderBookingPresenter extends StateNotifier<Booking>
           initialValue: initialState.persons,
           valueConverter: intDoubleConverter,
         )
-        ..addIntWithField<FormBuilderSegmentedControl<int>>(
+        ..integerWithField<FormBuilderSegmentedControl<int>>(
           name: 'babyBeds',
           initialValue: initialState.babyBeds,
         )
-        ..addRangeValues(
+        ..rangeValues(
           name: 'preferredPrice',
           initialValue: initialState.price == null
               ? const RangeValues(1000, 100000)
               : RangeValues(initialState.price!, initialState.price!),
         )
-        ..addText(
+        ..string(
           name: 'note',
           initialValue: initialState.note,
         ),

--- a/examples/form_companion_presenter_example/lib/auto_validation_vanilla_form.dart
+++ b/examples/form_companion_presenter_example/lib/auto_validation_vanilla_form.dart
@@ -154,14 +154,13 @@ class AutoValidationVanillaFormAccountPresenter extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             Validator.required,
             Validator.min(0),
           ],
-          stringConverter: intStringConverter,
         ),
     );
   }

--- a/examples/form_companion_presenter_example/lib/auto_validation_vanilla_form.dart
+++ b/examples/form_companion_presenter_example/lib/auto_validation_vanilla_form.dart
@@ -132,7 +132,7 @@ class AutoValidationVanillaFormAccountPresenter extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -143,18 +143,18 @@ class AutoValidationVanillaFormAccountPresenter extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             Validator.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [

--- a/examples/form_companion_presenter_example/lib/bulk_auto_validation_form_builder_account.dart
+++ b/examples/form_companion_presenter_example/lib/bulk_auto_validation_form_builder_account.dart
@@ -184,7 +184,7 @@ class BulkAutoValidationFormBuilderAccountPresenter
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -195,18 +195,18 @@ class BulkAutoValidationFormBuilderAccountPresenter
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             FormBuilderValidators.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
@@ -215,7 +215,7 @@ class BulkAutoValidationFormBuilderAccountPresenter
           ],
           stringConverter: intStringConverter,
         )
-        ..addEnumList<Region>(
+        ..enumeratedList<Region>(
           name: 'preferredRegions',
           initialValues: initialState.preferredRegsions,
         ),

--- a/examples/form_companion_presenter_example/lib/bulk_auto_validation_form_builder_account.dart
+++ b/examples/form_companion_presenter_example/lib/bulk_auto_validation_form_builder_account.dart
@@ -206,14 +206,13 @@ class BulkAutoValidationFormBuilderAccountPresenter
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             FormBuilderValidators.required,
             (context) => FormBuilderValidators.min(context, 0),
           ],
-          stringConverter: intStringConverter,
         )
         ..enumeratedList<Region>(
           name: 'preferredRegions',

--- a/examples/form_companion_presenter_example/lib/bulk_auto_validation_form_builder_booking.dart
+++ b/examples/form_companion_presenter_example/lib/bulk_auto_validation_form_builder_booking.dart
@@ -246,23 +246,23 @@ class BulkAutoValidationFormBuilderBookingPresenter
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addDateTimeRange(
+        ..dateTimeRange(
           name: 'stay',
           initialValue: initialState.stay,
         )
-        ..addDateTime(
+        ..dateTime(
           name: 'specialOfferDate',
           initialValue: initialState.specialOfferDate,
         )
-        ..addEnumWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
+        ..enumeratedWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
           name: 'roomType',
           initialValue: initialState.roomType,
         )
-        ..addEnumList<MealType>(
+        ..enumeratedList<MealType>(
           name: 'mealOffers',
           initialValues: initialState.mealOffers,
         )
-        ..addBool(
+        ..boolean(
           name: 'smoking',
           initialValue: initialState.smoking ?? false,
         )
@@ -271,17 +271,17 @@ class BulkAutoValidationFormBuilderBookingPresenter
           initialValue: initialState.persons,
           valueConverter: intDoubleConverter,
         )
-        ..addIntWithField<FormBuilderSegmentedControl<int>>(
+        ..integerWithField<FormBuilderSegmentedControl<int>>(
           name: 'babyBeds',
           initialValue: initialState.babyBeds,
         )
-        ..addRangeValues(
+        ..rangeValues(
           name: 'preferredPrice',
           initialValue: initialState.price == null
               ? const RangeValues(1000, 100000)
               : RangeValues(initialState.price!, initialState.price!),
         )
-        ..addText(
+        ..string(
           name: 'note',
           initialValue: initialState.note,
         ),

--- a/examples/form_companion_presenter_example/lib/bulk_auto_validation_vanilla_form.dart
+++ b/examples/form_companion_presenter_example/lib/bulk_auto_validation_vanilla_form.dart
@@ -135,7 +135,7 @@ class BulkAutoValidationVanillaFormAccountPresenter
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -146,18 +146,18 @@ class BulkAutoValidationVanillaFormAccountPresenter
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             Validator.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [

--- a/examples/form_companion_presenter_example/lib/bulk_auto_validation_vanilla_form.dart
+++ b/examples/form_companion_presenter_example/lib/bulk_auto_validation_vanilla_form.dart
@@ -157,14 +157,13 @@ class BulkAutoValidationVanillaFormAccountPresenter
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             Validator.required,
             Validator.min(0),
           ],
-          stringConverter: intStringConverter,
         ),
     );
   }

--- a/examples/form_companion_presenter_example/lib/components/account.dart
+++ b/examples/form_companion_presenter_example/lib/components/account.dart
@@ -205,7 +205,7 @@ class AccountPresenterTemplate extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
@@ -218,7 +218,6 @@ class AccountPresenterTemplate extends StateNotifier<Account>
             (context) => FormBuilderValidators.min(context, 0),
             //!macro endBuilderOnly
           ],
-          stringConverter: intStringConverter,
         )
         //!macro beginBuilderOnly
         ..enumeratedList<Region>(

--- a/examples/form_companion_presenter_example/lib/components/account.dart
+++ b/examples/form_companion_presenter_example/lib/components/account.dart
@@ -172,7 +172,7 @@ class AccountPresenterTemplate extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -189,7 +189,7 @@ class AccountPresenterTemplate extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
@@ -201,11 +201,11 @@ class AccountPresenterTemplate extends StateNotifier<Account>
             //!macro endBuilderOnly
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
@@ -221,7 +221,7 @@ class AccountPresenterTemplate extends StateNotifier<Account>
           stringConverter: intStringConverter,
         )
         //!macro beginBuilderOnly
-        ..addEnumList<Region>(
+        ..enumeratedList<Region>(
           name: 'preferredRegions',
           initialValues: initialState.preferredRegsions,
         )

--- a/examples/form_companion_presenter_example/lib/components/booking.dart
+++ b/examples/form_companion_presenter_example/lib/components/booking.dart
@@ -235,23 +235,23 @@ class BookingPresenterTemplate extends StateNotifier<Booking>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addDateTimeRange(
+        ..dateTimeRange(
           name: 'stay',
           initialValue: initialState.stay,
         )
-        ..addDateTime(
+        ..dateTime(
           name: 'specialOfferDate',
           initialValue: initialState.specialOfferDate,
         )
-        ..addEnumWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
+        ..enumeratedWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
           name: 'roomType',
           initialValue: initialState.roomType,
         )
-        ..addEnumList<MealType>(
+        ..enumeratedList<MealType>(
           name: 'mealOffers',
           initialValues: initialState.mealOffers,
         )
-        ..addBool(
+        ..boolean(
           name: 'smoking',
           initialValue: initialState.smoking ?? false,
         )
@@ -260,17 +260,17 @@ class BookingPresenterTemplate extends StateNotifier<Booking>
           initialValue: initialState.persons,
           valueConverter: intDoubleConverter,
         )
-        ..addIntWithField<FormBuilderSegmentedControl<int>>(
+        ..integerWithField<FormBuilderSegmentedControl<int>>(
           name: 'babyBeds',
           initialValue: initialState.babyBeds,
         )
-        ..addRangeValues(
+        ..rangeValues(
           name: 'preferredPrice',
           initialValue: initialState.price == null
               ? const RangeValues(1000, 100000)
               : RangeValues(initialState.price!, initialState.price!),
         )
-        ..addText(
+        ..string(
           name: 'note',
           initialValue: initialState.note,
         ),

--- a/examples/form_companion_presenter_example/lib/manual_validation_form_builder_account.dart
+++ b/examples/form_companion_presenter_example/lib/manual_validation_form_builder_account.dart
@@ -201,14 +201,13 @@ class ManualValidationFormBuilderAccountPresenter extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             FormBuilderValidators.required,
             (context) => FormBuilderValidators.min(context, 0),
           ],
-          stringConverter: intStringConverter,
         )
         ..enumeratedList<Region>(
           name: 'preferredRegions',

--- a/examples/form_companion_presenter_example/lib/manual_validation_form_builder_account.dart
+++ b/examples/form_companion_presenter_example/lib/manual_validation_form_builder_account.dart
@@ -179,7 +179,7 @@ class ManualValidationFormBuilderAccountPresenter extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -190,18 +190,18 @@ class ManualValidationFormBuilderAccountPresenter extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             FormBuilderValidators.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
@@ -210,7 +210,7 @@ class ManualValidationFormBuilderAccountPresenter extends StateNotifier<Account>
           ],
           stringConverter: intStringConverter,
         )
-        ..addEnumList<Region>(
+        ..enumeratedList<Region>(
           name: 'preferredRegions',
           initialValues: initialState.preferredRegsions,
         ),

--- a/examples/form_companion_presenter_example/lib/manual_validation_form_builder_booking.dart
+++ b/examples/form_companion_presenter_example/lib/manual_validation_form_builder_booking.dart
@@ -241,23 +241,23 @@ class ManualValidationFormBuilderBookingPresenter extends StateNotifier<Booking>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addDateTimeRange(
+        ..dateTimeRange(
           name: 'stay',
           initialValue: initialState.stay,
         )
-        ..addDateTime(
+        ..dateTime(
           name: 'specialOfferDate',
           initialValue: initialState.specialOfferDate,
         )
-        ..addEnumWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
+        ..enumeratedWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
           name: 'roomType',
           initialValue: initialState.roomType,
         )
-        ..addEnumList<MealType>(
+        ..enumeratedList<MealType>(
           name: 'mealOffers',
           initialValues: initialState.mealOffers,
         )
-        ..addBool(
+        ..boolean(
           name: 'smoking',
           initialValue: initialState.smoking ?? false,
         )
@@ -266,17 +266,17 @@ class ManualValidationFormBuilderBookingPresenter extends StateNotifier<Booking>
           initialValue: initialState.persons,
           valueConverter: intDoubleConverter,
         )
-        ..addIntWithField<FormBuilderSegmentedControl<int>>(
+        ..integerWithField<FormBuilderSegmentedControl<int>>(
           name: 'babyBeds',
           initialValue: initialState.babyBeds,
         )
-        ..addRangeValues(
+        ..rangeValues(
           name: 'preferredPrice',
           initialValue: initialState.price == null
               ? const RangeValues(1000, 100000)
               : RangeValues(initialState.price!, initialState.price!),
         )
-        ..addText(
+        ..string(
           name: 'note',
           initialValue: initialState.note,
         ),

--- a/examples/form_companion_presenter_example/lib/manual_validation_vanilla_form.dart
+++ b/examples/form_companion_presenter_example/lib/manual_validation_vanilla_form.dart
@@ -130,7 +130,7 @@ class ManualValidationVanillaFormAccountPresenter extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -141,18 +141,18 @@ class ManualValidationVanillaFormAccountPresenter extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             Validator.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [

--- a/examples/form_companion_presenter_example/lib/manual_validation_vanilla_form.dart
+++ b/examples/form_companion_presenter_example/lib/manual_validation_vanilla_form.dart
@@ -152,14 +152,13 @@ class ManualValidationVanillaFormAccountPresenter extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             Validator.required,
             Validator.min(0),
           ],
-          stringConverter: intStringConverter,
         ),
     );
   }

--- a/melos.yaml
+++ b/melos.yaml
@@ -11,7 +11,7 @@ scripts:
     description: Run `flutter analyze` in all packages.
 
   analyze:core:
-    run: melos exec -c 1 -- flutter analyze .
+    run: melos exec -c 1 -- fvm flutter analyze .
     description: Run `flutter analyze` in all packages.
     select-package:
       flutter: true
@@ -19,23 +19,30 @@ scripts:
       ignore: dev_env
 
   test:
-    run: melos run test:core --no-select
+    run: melos run test:flutter --no-select && melos run test:dart --no-select
     description: Run Flutter tests for a specific package in this project.
 
-  test:core:
+  test:flutter:
     run: melos exec -c 1 --fail-fast -- fvm flutter test --reporter=expanded --coverage
     description: Run Flutter tests for a specific package in this project.
     select-package:
       flutter: true
       dir-exists: test
-      # TEMP
-      ignore: '*examples'
+      ignore:
+        - 'form_companion_generator_test_targets'
+
+  test:dart:
+    run: melos exec -c 1 --fail-fast -- fvm dart test --reporter=expanded --coverage=coverage
+    description: Run Dart tests for a specific package in this project.
+    select-package:
+      flutter: false
+      dir-exists: test
 
   build_runner:
-    run: melos run freezed:generate --no-select
+    run: melos run build_runner:core --no-select
     description: Do source generation for freezed
   
-  freezed:generate:
+  build_runner:core:
     run: melos exec -c 1 --fail-fast -- fvm flutter pub run build_runner build --delete-conflicting-outputs
     select-package:
       flutter: true

--- a/packages/form_builder_companion_presenter/example/lib/auto_validation_form_builder_account.dart
+++ b/packages/form_builder_companion_presenter/example/lib/auto_validation_form_builder_account.dart
@@ -203,14 +203,13 @@ class AutoValidationFormBuilderAccountPresenter extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             FormBuilderValidators.required,
             (context) => FormBuilderValidators.min(context, 0),
           ],
-          stringConverter: intStringConverter,
         )
         ..enumeratedList<Region>(
           name: 'preferredRegions',

--- a/packages/form_builder_companion_presenter/example/lib/auto_validation_form_builder_account.dart
+++ b/packages/form_builder_companion_presenter/example/lib/auto_validation_form_builder_account.dart
@@ -181,7 +181,7 @@ class AutoValidationFormBuilderAccountPresenter extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -192,18 +192,18 @@ class AutoValidationFormBuilderAccountPresenter extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             FormBuilderValidators.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
@@ -212,7 +212,7 @@ class AutoValidationFormBuilderAccountPresenter extends StateNotifier<Account>
           ],
           stringConverter: intStringConverter,
         )
-        ..addEnumList<Region>(
+        ..enumeratedList<Region>(
           name: 'preferredRegions',
           initialValues: initialState.preferredRegsions,
         ),

--- a/packages/form_builder_companion_presenter/example/lib/auto_validation_form_builder_booking.dart
+++ b/packages/form_builder_companion_presenter/example/lib/auto_validation_form_builder_booking.dart
@@ -244,23 +244,23 @@ class AutoValidationFormBuilderBookingPresenter extends StateNotifier<Booking>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addDateTimeRange(
+        ..dateTimeRange(
           name: 'stay',
           initialValue: initialState.stay,
         )
-        ..addDateTime(
+        ..dateTime(
           name: 'specialOfferDate',
           initialValue: initialState.specialOfferDate,
         )
-        ..addEnumWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
+        ..enumeratedWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
           name: 'roomType',
           initialValue: initialState.roomType,
         )
-        ..addEnumList<MealType>(
+        ..enumeratedList<MealType>(
           name: 'mealOffers',
           initialValues: initialState.mealOffers,
         )
-        ..addBool(
+        ..boolean(
           name: 'smoking',
           initialValue: initialState.smoking ?? false,
         )
@@ -269,17 +269,17 @@ class AutoValidationFormBuilderBookingPresenter extends StateNotifier<Booking>
           initialValue: initialState.persons,
           valueConverter: intDoubleConverter,
         )
-        ..addIntWithField<FormBuilderSegmentedControl<int>>(
+        ..integerWithField<FormBuilderSegmentedControl<int>>(
           name: 'babyBeds',
           initialValue: initialState.babyBeds,
         )
-        ..addRangeValues(
+        ..rangeValues(
           name: 'preferredPrice',
           initialValue: initialState.price == null
               ? const RangeValues(1000, 100000)
               : RangeValues(initialState.price!, initialState.price!),
         )
-        ..addText(
+        ..string(
           name: 'note',
           initialValue: initialState.note,
         ),

--- a/packages/form_builder_companion_presenter/example/lib/bulk_auto_validation_form_builder_account.dart
+++ b/packages/form_builder_companion_presenter/example/lib/bulk_auto_validation_form_builder_account.dart
@@ -184,7 +184,7 @@ class BulkAutoValidationFormBuilderAccountPresenter
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -195,18 +195,18 @@ class BulkAutoValidationFormBuilderAccountPresenter
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             FormBuilderValidators.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
@@ -215,7 +215,7 @@ class BulkAutoValidationFormBuilderAccountPresenter
           ],
           stringConverter: intStringConverter,
         )
-        ..addEnumList<Region>(
+        ..enumeratedList<Region>(
           name: 'preferredRegions',
           initialValues: initialState.preferredRegsions,
         ),

--- a/packages/form_builder_companion_presenter/example/lib/bulk_auto_validation_form_builder_account.dart
+++ b/packages/form_builder_companion_presenter/example/lib/bulk_auto_validation_form_builder_account.dart
@@ -206,14 +206,13 @@ class BulkAutoValidationFormBuilderAccountPresenter
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             FormBuilderValidators.required,
             (context) => FormBuilderValidators.min(context, 0),
           ],
-          stringConverter: intStringConverter,
         )
         ..enumeratedList<Region>(
           name: 'preferredRegions',

--- a/packages/form_builder_companion_presenter/example/lib/bulk_auto_validation_form_builder_booking.dart
+++ b/packages/form_builder_companion_presenter/example/lib/bulk_auto_validation_form_builder_booking.dart
@@ -246,23 +246,23 @@ class BulkAutoValidationFormBuilderBookingPresenter
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addDateTimeRange(
+        ..dateTimeRange(
           name: 'stay',
           initialValue: initialState.stay,
         )
-        ..addDateTime(
+        ..dateTime(
           name: 'specialOfferDate',
           initialValue: initialState.specialOfferDate,
         )
-        ..addEnumWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
+        ..enumeratedWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
           name: 'roomType',
           initialValue: initialState.roomType,
         )
-        ..addEnumList<MealType>(
+        ..enumeratedList<MealType>(
           name: 'mealOffers',
           initialValues: initialState.mealOffers,
         )
-        ..addBool(
+        ..boolean(
           name: 'smoking',
           initialValue: initialState.smoking ?? false,
         )
@@ -271,17 +271,17 @@ class BulkAutoValidationFormBuilderBookingPresenter
           initialValue: initialState.persons,
           valueConverter: intDoubleConverter,
         )
-        ..addIntWithField<FormBuilderSegmentedControl<int>>(
+        ..integerWithField<FormBuilderSegmentedControl<int>>(
           name: 'babyBeds',
           initialValue: initialState.babyBeds,
         )
-        ..addRangeValues(
+        ..rangeValues(
           name: 'preferredPrice',
           initialValue: initialState.price == null
               ? const RangeValues(1000, 100000)
               : RangeValues(initialState.price!, initialState.price!),
         )
-        ..addText(
+        ..string(
           name: 'note',
           initialValue: initialState.note,
         ),

--- a/packages/form_builder_companion_presenter/example/lib/manual_validation_form_builder_account.dart
+++ b/packages/form_builder_companion_presenter/example/lib/manual_validation_form_builder_account.dart
@@ -201,14 +201,13 @@ class ManualValidationFormBuilderAccountPresenter extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             FormBuilderValidators.required,
             (context) => FormBuilderValidators.min(context, 0),
           ],
-          stringConverter: intStringConverter,
         )
         ..enumeratedList<Region>(
           name: 'preferredRegions',

--- a/packages/form_builder_companion_presenter/example/lib/manual_validation_form_builder_account.dart
+++ b/packages/form_builder_companion_presenter/example/lib/manual_validation_form_builder_account.dart
@@ -179,7 +179,7 @@ class ManualValidationFormBuilderAccountPresenter extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -190,18 +190,18 @@ class ManualValidationFormBuilderAccountPresenter extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             FormBuilderValidators.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
@@ -210,7 +210,7 @@ class ManualValidationFormBuilderAccountPresenter extends StateNotifier<Account>
           ],
           stringConverter: intStringConverter,
         )
-        ..addEnumList<Region>(
+        ..enumeratedList<Region>(
           name: 'preferredRegions',
           initialValues: initialState.preferredRegsions,
         ),

--- a/packages/form_builder_companion_presenter/example/lib/manual_validation_form_builder_booking.dart
+++ b/packages/form_builder_companion_presenter/example/lib/manual_validation_form_builder_booking.dart
@@ -241,23 +241,23 @@ class ManualValidationFormBuilderBookingPresenter extends StateNotifier<Booking>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addDateTimeRange(
+        ..dateTimeRange(
           name: 'stay',
           initialValue: initialState.stay,
         )
-        ..addDateTime(
+        ..dateTime(
           name: 'specialOfferDate',
           initialValue: initialState.specialOfferDate,
         )
-        ..addEnumWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
+        ..enumeratedWithField<RoomType, FormBuilderRadioGroup<RoomType>>(
           name: 'roomType',
           initialValue: initialState.roomType,
         )
-        ..addEnumList<MealType>(
+        ..enumeratedList<MealType>(
           name: 'mealOffers',
           initialValues: initialState.mealOffers,
         )
-        ..addBool(
+        ..boolean(
           name: 'smoking',
           initialValue: initialState.smoking ?? false,
         )
@@ -266,17 +266,17 @@ class ManualValidationFormBuilderBookingPresenter extends StateNotifier<Booking>
           initialValue: initialState.persons,
           valueConverter: intDoubleConverter,
         )
-        ..addIntWithField<FormBuilderSegmentedControl<int>>(
+        ..integerWithField<FormBuilderSegmentedControl<int>>(
           name: 'babyBeds',
           initialValue: initialState.babyBeds,
         )
-        ..addRangeValues(
+        ..rangeValues(
           name: 'preferredPrice',
           initialValue: initialState.price == null
               ? const RangeValues(1000, 100000)
               : RangeValues(initialState.price!, initialState.price!),
         )
-        ..addText(
+        ..string(
           name: 'note',
           initialValue: initialState.note,
         ),

--- a/packages/form_builder_companion_presenter/lib/src/form_builder_extension.dart
+++ b/packages/form_builder_companion_presenter/lib/src/form_builder_extension.dart
@@ -3,8 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:form_companion_presenter/form_companion_presenter.dart';
 
-// TODO(yfakariya): More be DSL-ish with removing `add` prefix.
-
 /// Defines convinient extension methos for [PropertyDescriptorsBuilder] to
 /// define typical type combinations with `flutter_form_builder`.
 extension FormBuilderCompanionPropertyDescriptorsBuilderExtension
@@ -17,7 +15,7 @@ extension FormBuilderCompanionPropertyDescriptorsBuilderExtension
   /// validation framework requires live [BuildContext] to initialize validator,
   /// and current [Locale] of the application should be stored to
   /// [BuildContext].
-  void addBoolList({
+  void booleanList({
     required String name,
     List<bool>? initialValues,
   }) =>
@@ -34,7 +32,7 @@ extension FormBuilderCompanionPropertyDescriptorsBuilderExtension
   /// validation framework requires live [BuildContext] to initialize validator,
   /// and current [Locale] of the application should be stored to
   /// [BuildContext].
-  void addEnumList<T extends Enum>({
+  void enumeratedList<T extends Enum>({
     required String name,
     List<T>? initialValues,
   }) =>
@@ -48,7 +46,7 @@ extension FormBuilderCompanionPropertyDescriptorsBuilderExtension
   /// validation framework requires live [BuildContext] to initialize validator,
   /// and current [Locale] of the application should be stored to
   /// [BuildContext].
-  void addDateTime({
+  void dateTime({
     required String name,
     List<FormFieldValidatorFactory<DateTime>>? validatorFactories,
     List<AsyncValidatorFactory<DateTime>>? asyncValidatorFactories,
@@ -69,7 +67,7 @@ extension FormBuilderCompanionPropertyDescriptorsBuilderExtension
   /// validation framework requires live [BuildContext] to initialize validator,
   /// and current [Locale] of the application should be stored to
   /// [BuildContext].
-  void addDateTimeRange({
+  void dateTimeRange({
     required String name,
     List<FormFieldValidatorFactory<DateTimeRange>>? validatorFactories,
     List<AsyncValidatorFactory<DateTimeRange>>? asyncValidatorFactories,
@@ -90,7 +88,7 @@ extension FormBuilderCompanionPropertyDescriptorsBuilderExtension
   /// validation framework requires live [BuildContext] to initialize validator,
   /// and current [Locale] of the application should be stored to
   /// [BuildContext].
-  void addRangeValues({
+  void rangeValues({
     required String name,
     List<FormFieldValidatorFactory<RangeValues>>? validatorFactories,
     List<AsyncValidatorFactory<RangeValues>>? asyncValidatorFactories,

--- a/packages/form_builder_companion_presenter/lib/src/form_companion_builder_extension.dart
+++ b/packages/form_builder_companion_presenter/lib/src/form_companion_builder_extension.dart
@@ -18,7 +18,7 @@ extension FormCompanionBuilderCompanionPropertyDescriptorsBuilderExtension
   /// [BuildContext].
   ///
   /// [TField] affects `FormFieldFactory` generation by `form_companion_generator`.
-  void addBoolListWithField<TField extends FormField<List<bool>>>({
+  void booleanListWithField<TField extends FormField<List<bool>>>({
     required String name,
     List<bool>? initialValues,
   }) =>
@@ -38,7 +38,8 @@ extension FormCompanionBuilderCompanionPropertyDescriptorsBuilderExtension
   /// [BuildContext].
   ///
   /// [TField] affects `FormFieldFactory` generation by `form_companion_generator`.
-  void addEnumListWithField<T extends Enum, TField extends FormField<List<T>>>({
+  void enumeratedListWithField<T extends Enum,
+          TField extends FormField<List<T>>>({
     required String name,
     List<T>? initialValues,
   }) =>

--- a/packages/form_builder_companion_presenter/pubspec.yaml
+++ b/packages/form_builder_companion_presenter/pubspec.yaml
@@ -22,4 +22,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-dependency_overrides: {form_companion_presenter: {path: ../../packages/form_companion_presenter}}

--- a/packages/form_companion_generator/.gitignore
+++ b/packages/form_companion_generator/.gitignore
@@ -27,3 +27,5 @@
 .dart_tool/
 .packages
 build/
+
+coverage/

--- a/packages/form_companion_generator_test/lib/presenter.dart
+++ b/packages/form_companion_generator_test/lib/presenter.dart
@@ -199,20 +199,20 @@ class InferredTypes with CompanionPresenterMixin, FormBuilderCompanionMixin {
           name: 'addWithValueConverter',
           valueConverter: intStringConverter,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'addStringWithStringConverter',
           stringConverter: bigIntStringConverter,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'addStringWithInitialValue',
           initialValue: 1.23,
           stringConverter: doubleStringConverter,
         )
-        ..addEnum(
+        ..enumerated(
           name: 'addEnumWithInitialValue',
           initialValue: MyEnum.one,
         )
-        ..addEnumList(
+        ..enumeratedList(
           name: 'addEnumListWithInitialValue',
           initialValues: [MyEnum.one],
         ),
@@ -252,7 +252,7 @@ class RawAddBigIntWithFieldVanilla
     with CompanionPresenterMixin, FormCompanionMixin {
   RawAddBigIntWithFieldVanilla() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addBigIntWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..bigIntWithField(name: 'propRaw'),
     );
   }
 
@@ -265,7 +265,7 @@ class RawAddBoolWithFieldVanilla
     with CompanionPresenterMixin, FormCompanionMixin {
   RawAddBoolWithFieldVanilla() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addBoolWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..booleanWithField(name: 'propRaw'),
     );
   }
 
@@ -278,7 +278,7 @@ class RawAddDoubleWithFieldVanilla
     with CompanionPresenterMixin, FormCompanionMixin {
   RawAddDoubleWithFieldVanilla() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addDoubleWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..realWithField(name: 'propRaw'),
     );
   }
 
@@ -291,7 +291,7 @@ class RawAddEnumWithFieldVanilla
     with CompanionPresenterMixin, FormCompanionMixin {
   RawAddEnumWithFieldVanilla() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addEnumWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..enumeratedWithField(name: 'propRaw'),
     );
   }
 
@@ -304,7 +304,7 @@ class RawAddIntWithFieldVanilla
     with CompanionPresenterMixin, FormCompanionMixin {
   RawAddIntWithFieldVanilla() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addIntWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..integerWithField(name: 'propRaw'),
     );
   }
 
@@ -318,7 +318,7 @@ class RawAddStringWithFieldVanilla
   RawAddStringWithFieldVanilla() {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addStringWithField(
+        ..stringConvertibleWithField(
           name: 'propRaw',
           stringConverter: StringConverter.fromCallbacks(
             stringify: (v, l) => v.toString(),
@@ -363,7 +363,7 @@ class RawAddBigIntWithFieldFormBuilder
     with CompanionPresenterMixin, FormBuilderCompanionMixin {
   RawAddBigIntWithFieldFormBuilder() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addBigIntWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..bigIntWithField(name: 'propRaw'),
     );
   }
 
@@ -376,7 +376,7 @@ class RawAddBoolListWithFieldFormBuilder
     with CompanionPresenterMixin, FormBuilderCompanionMixin {
   RawAddBoolListWithFieldFormBuilder() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addBoolListWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..booleanListWithField(name: 'propRaw'),
     );
   }
 
@@ -389,7 +389,7 @@ class RawAddBoolWithFieldFormBuilder
     with CompanionPresenterMixin, FormBuilderCompanionMixin {
   RawAddBoolWithFieldFormBuilder() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addBoolWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..booleanWithField(name: 'propRaw'),
     );
   }
 
@@ -402,7 +402,7 @@ class RawAddDoubleWithFieldFormBuilder
     with CompanionPresenterMixin, FormBuilderCompanionMixin {
   RawAddDoubleWithFieldFormBuilder() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addDoubleWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..realWithField(name: 'propRaw'),
     );
   }
 
@@ -415,7 +415,7 @@ class RawAddEnumListWithFieldFormBuilder
     with CompanionPresenterMixin, FormBuilderCompanionMixin {
   RawAddEnumListWithFieldFormBuilder() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addEnumListWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..enumeratedListWithField(name: 'propRaw'),
     );
   }
 
@@ -428,7 +428,7 @@ class RawAddEnumWithFieldFormBuilder
     with CompanionPresenterMixin, FormBuilderCompanionMixin {
   RawAddEnumWithFieldFormBuilder() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addEnumWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..enumeratedWithField(name: 'propRaw'),
     );
   }
 
@@ -441,7 +441,7 @@ class RawAddIntWithFieldFormBuilder
     with CompanionPresenterMixin, FormBuilderCompanionMixin {
   RawAddIntWithFieldFormBuilder() {
     initializeCompanionMixin(
-      PropertyDescriptorsBuilder()..addIntWithField(name: 'propRaw'),
+      PropertyDescriptorsBuilder()..integerWithField(name: 'propRaw'),
     );
   }
 
@@ -455,7 +455,7 @@ class RawAddStringWithFieldFormBuilder
   RawAddStringWithFieldFormBuilder() {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addStringWithField(
+        ..stringConvertibleWithField(
           name: 'propRaw',
           stringConverter: StringConverter.fromCallbacks(
             stringify: (v, l) => v.toString(),
@@ -475,13 +475,13 @@ class ConvinientExtensionMethod
   ConvinientExtensionMethod() {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addInt(name: 'propInt')
-        ..addText(name: 'propString')
-        ..addBool(name: 'propBool')
-        ..addEnum<MyEnum>(name: 'propEnum')
-        ..addEnumList<MyEnum>(name: 'propEnumList')
-        ..addDoubleWithField<FormBuilderSlider>(name: 'propDouble')
-        ..addEnumListWithField<MyEnum, FormBuilderCheckboxGroup<MyEnum>>(
+        ..integerText(name: 'propInt')
+        ..string(name: 'propString')
+        ..boolean(name: 'propBool')
+        ..enumerated<MyEnum>(name: 'propEnum')
+        ..enumeratedList<MyEnum>(name: 'propEnumList')
+        ..realWithField<FormBuilderSlider>(name: 'propDouble')
+        ..enumeratedListWithField<MyEnum, FormBuilderCheckboxGroup<MyEnum>>(
           name: 'propEnumList2',
         ),
     );

--- a/packages/form_companion_generator_test/test/src/the_form_buider_presenter.dart
+++ b/packages/form_companion_generator_test/test/src/the_form_buider_presenter.dart
@@ -15,34 +15,34 @@ class TheFormBuilderPresenter
   TheFormBuilderPresenter() {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(name: 'propString')
-        ..addEnum<MyEnum>(name: 'propEnum')
-        ..addBool(name: 'propBool')
-        ..addDateTime(name: 'propDateTime')
-        ..addDateTimeRange(name: 'propDateTimeRange')
-        ..addRangeValues(name: 'propRangeValues')
-        ..addEnumList<MyEnum>(name: 'propEnumList')
-        ..addBoolList(name: 'propBoolList')
-        ..addBoolWithField<FormBuilderCheckbox>(name: 'propBoolCheckBox')
-        ..addEnumListWithField<MyEnum, FormBuilderCheckboxGroup<MyEnum>>(
+        ..string(name: 'propString')
+        ..enumerated<MyEnum>(name: 'propEnum')
+        ..boolean(name: 'propBool')
+        ..dateTime(name: 'propDateTime')
+        ..dateTimeRange(name: 'propDateTimeRange')
+        ..rangeValues(name: 'propRangeValues')
+        ..enumeratedList<MyEnum>(name: 'propEnumList')
+        ..booleanList(name: 'propBoolList')
+        ..booleanWithField<FormBuilderCheckbox>(name: 'propBoolCheckBox')
+        ..enumeratedListWithField<MyEnum, FormBuilderCheckboxGroup<MyEnum>>(
           name: 'propEnumListCheckBoxGroup',
         )
-        ..addEnumWithField<MyEnum, FormBuilderChoiceChip<MyEnum>>(
+        ..enumeratedWithField<MyEnum, FormBuilderChoiceChip<MyEnum>>(
           name: 'propEnumChoiceChip',
         )
-        ..addEnumListWithField<MyEnum, FormBuilderFilterChip<MyEnum>>(
+        ..enumeratedListWithField<MyEnum, FormBuilderFilterChip<MyEnum>>(
           name: 'propEnumListFilterChip',
         )
-        ..addEnumWithField<MyEnum, FormBuilderRadioGroup<MyEnum>>(
+        ..enumeratedWithField<MyEnum, FormBuilderRadioGroup<MyEnum>>(
           name: 'propEnumRadioGroup',
         )
-        ..addEnumWithField<MyEnum, FormBuilderSegmentedControl<MyEnum>>(
+        ..enumeratedWithField<MyEnum, FormBuilderSegmentedControl<MyEnum>>(
           name: 'propEnumSegmentedControl',
         )
-        ..addDoubleWithField<FormBuilderSlider>(
+        ..realWithField<FormBuilderSlider>(
           name: 'propDoubleSlider',
         )
-        ..addInt(
+        ..integerText(
           name: 'propInt',
         ),
     );

--- a/packages/form_companion_generator_test/test/src/the_form_presenter.dart
+++ b/packages/form_companion_generator_test/test/src/the_form_presenter.dart
@@ -12,13 +12,13 @@ class TheFormPresenter with CompanionPresenterMixin, FormCompanionMixin {
   TheFormPresenter() {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(name: 'propString')
-        ..addEnum<MyEnum>(name: 'propEnum')
+        ..string(name: 'propString')
+        ..enumerated<MyEnum>(name: 'propEnum')
         ..addWithField<List<String>, List<String>,
             DropdownButtonFormField<List<String>>>(
           name: 'propStringList',
         )
-        ..addInt(
+        ..integerText(
           name: 'propInt',
         ),
     );

--- a/packages/form_companion_presenter/example/lib/auto_validation_vanilla_form.dart
+++ b/packages/form_companion_presenter/example/lib/auto_validation_vanilla_form.dart
@@ -154,14 +154,13 @@ class AutoValidationVanillaFormAccountPresenter extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             Validator.required,
             Validator.min(0),
           ],
-          stringConverter: intStringConverter,
         ),
     );
   }

--- a/packages/form_companion_presenter/example/lib/auto_validation_vanilla_form.dart
+++ b/packages/form_companion_presenter/example/lib/auto_validation_vanilla_form.dart
@@ -132,7 +132,7 @@ class AutoValidationVanillaFormAccountPresenter extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -143,18 +143,18 @@ class AutoValidationVanillaFormAccountPresenter extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             Validator.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [

--- a/packages/form_companion_presenter/example/lib/bulk_auto_validation_vanilla_form.dart
+++ b/packages/form_companion_presenter/example/lib/bulk_auto_validation_vanilla_form.dart
@@ -135,7 +135,7 @@ class BulkAutoValidationVanillaFormAccountPresenter
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -146,18 +146,18 @@ class BulkAutoValidationVanillaFormAccountPresenter
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             Validator.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [

--- a/packages/form_companion_presenter/example/lib/bulk_auto_validation_vanilla_form.dart
+++ b/packages/form_companion_presenter/example/lib/bulk_auto_validation_vanilla_form.dart
@@ -157,14 +157,13 @@ class BulkAutoValidationVanillaFormAccountPresenter
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             Validator.required,
             Validator.min(0),
           ],
-          stringConverter: intStringConverter,
         ),
     );
   }

--- a/packages/form_companion_presenter/example/lib/manual_validation_vanilla_form.dart
+++ b/packages/form_companion_presenter/example/lib/manual_validation_vanilla_form.dart
@@ -130,7 +130,7 @@ class ManualValidationVanillaFormAccountPresenter extends StateNotifier<Account>
   ) : super(initialState) {
     initializeCompanionMixin(
       PropertyDescriptorsBuilder()
-        ..addText(
+        ..string(
           name: 'id',
           initialValue: initialState.id,
           validatorFactories: [
@@ -141,18 +141,18 @@ class ManualValidationVanillaFormAccountPresenter extends StateNotifier<Account>
             Validator.id,
           ],
         )
-        ..addText(
+        ..string(
           name: 'name',
           initialValue: initialState.name,
           validatorFactories: [
             Validator.required,
           ],
         )
-        ..addEnum<Gender>(
+        ..enumerated<Gender>(
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..addString(
+        ..stringConvertible(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [

--- a/packages/form_companion_presenter/example/lib/manual_validation_vanilla_form.dart
+++ b/packages/form_companion_presenter/example/lib/manual_validation_vanilla_form.dart
@@ -152,14 +152,13 @@ class ManualValidationVanillaFormAccountPresenter extends StateNotifier<Account>
           name: 'gender',
           initialValue: initialState.gender,
         )
-        ..stringConvertible(
+        ..integerText(
           name: 'age',
           initialValue: initialState.age,
           validatorFactories: [
             Validator.required,
             Validator.min(0),
           ],
-          stringConverter: intStringConverter,
         ),
     );
   }

--- a/packages/form_companion_presenter/lib/src/form_companion_annotation.dart
+++ b/packages/form_companion_presenter/lib/src/form_companion_annotation.dart
@@ -71,7 +71,8 @@ extension FormCompanionPropertyDescriptorBuilderExtensions
   /// {@macro pdb_add_remarks}
   ///
   /// [TField] affects `FormFieldFactory` generation by `form_companion_generator`.
-  void addStringWithField<P extends Object, TField extends FormField<String>>({
+  void stringConvertibleWithField<P extends Object,
+          TField extends FormField<String>>({
     required String name,
     List<FormFieldValidatorFactory<String>>? validatorFactories,
     List<AsyncValidatorFactory<String>>? asyncValidatorFactories,
@@ -92,7 +93,7 @@ extension FormCompanionPropertyDescriptorBuilderExtensions
   /// {@macro pdb_add_remarks}
   ///
   /// [TField] affects `FormFieldFactory` generation by `form_companion_generator`.
-  void addBoolWithField<TField extends FormField<bool>>({
+  void booleanWithField<TField extends FormField<bool>>({
     required String name,
     bool initialValue = false,
   }) =>
@@ -107,7 +108,7 @@ extension FormCompanionPropertyDescriptorBuilderExtensions
   /// {@macro pdb_add_remarks}
   ///
   /// [TField] affects `FormFieldFactory` generation by `form_companion_generator`.
-  void addEnumWithField<T extends Enum, TField extends FormField<T>>({
+  void enumeratedWithField<T extends Enum, TField extends FormField<T>>({
     required String name,
     T? initialValue,
   }) =>
@@ -122,7 +123,7 @@ extension FormCompanionPropertyDescriptorBuilderExtensions
   /// {@macro pdb_add_remarks}
   ///
   /// [TField] affects `FormFieldFactory` generation by `form_companion_generator`.
-  void addIntWithField<TField extends FormField<int>>({
+  void integerWithField<TField extends FormField<int>>({
     required String name,
     List<FormFieldValidatorFactory<int>>? validatorFactories,
     List<AsyncValidatorFactory<int>>? asyncValidatorFactories,
@@ -141,7 +142,7 @@ extension FormCompanionPropertyDescriptorBuilderExtensions
   /// {@macro pdb_add_remarks}
   ///
   /// [TField] affects `FormFieldFactory` generation by `form_companion_generator`.
-  void addDoubleWithField<TField extends FormField<double>>({
+  void realWithField<TField extends FormField<double>>({
     required String name,
     List<FormFieldValidatorFactory<double>>? validatorFactories,
     List<AsyncValidatorFactory<double>>? asyncValidatorFactories,
@@ -160,7 +161,7 @@ extension FormCompanionPropertyDescriptorBuilderExtensions
   /// {@macro pdb_add_remarks}
   ///
   /// [TField] affects `FormFieldFactory` generation by `form_companion_generator`.
-  void addBigIntWithField<TField extends FormField<BigInt>>({
+  void bigIntWithField<TField extends FormField<BigInt>>({
     required String name,
     List<FormFieldValidatorFactory<BigInt>>? validatorFactories,
     List<AsyncValidatorFactory<BigInt>>? asyncValidatorFactories,

--- a/packages/form_companion_presenter/lib/src/form_companion_mixin/property_descriptor_builder.dart
+++ b/packages/form_companion_presenter/lib/src/form_companion_mixin/property_descriptor_builder.dart
@@ -59,7 +59,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
   /// form field value type [String].
   ///
   /// {@macro pdb_add_remarks}
-  void addString<P extends Object>({
+  void stringConvertible<P extends Object>({
     required String name,
     List<FormFieldValidatorFactory<String>>? validatorFactories,
     List<AsyncValidatorFactory<String>>? asyncValidatorFactories,
@@ -78,7 +78,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
   /// form field value type.
   ///
   /// {@macro pdb_add_remarks}
-  void addText({
+  void string({
     required String name,
     List<FormFieldValidatorFactory<String>>? validatorFactories,
     List<AsyncValidatorFactory<String>>? asyncValidatorFactories,
@@ -95,7 +95,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
   /// form field value type.
   ///
   /// {@macro pdb_add_remarks}
-  void addBool({
+  void boolean({
     required String name,
     bool initialValue = false,
   }) =>
@@ -105,7 +105,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
   /// and form field value type.
   ///
   /// {@macro pdb_add_remarks}
-  void addEnum<T extends Enum>({
+  void enumerated<T extends Enum>({
     required String name,
     T? initialValue,
   }) =>
@@ -115,7 +115,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
   /// form field value type [String].
   ///
   /// {@macro pdb_add_remarks}
-  void addInt({
+  void integerText({
     required String name,
     List<FormFieldValidatorFactory<String>>? validatorFactories,
     List<AsyncValidatorFactory<String>>? asyncValidatorFactories,
@@ -132,7 +132,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
   /// form field value type [String].
   ///
   /// {@macro pdb_add_remarks}
-  void addDouble({
+  void realText({
     required String name,
     List<FormFieldValidatorFactory<String>>? validatorFactories,
     List<AsyncValidatorFactory<String>>? asyncValidatorFactories,
@@ -149,7 +149,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
   /// form field value type [String].
   ///
   /// {@macro pdb_add_remarks}
-  void addBigInt({
+  void bigIntText({
     required String name,
     List<FormFieldValidatorFactory<String>>? validatorFactories,
     List<AsyncValidatorFactory<String>>? asyncValidatorFactories,

--- a/packages/form_companion_presenter/lib/src/form_companion_mixin/property_descriptor_builder.dart
+++ b/packages/form_companion_presenter/lib/src/form_companion_mixin/property_descriptor_builder.dart
@@ -126,6 +126,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
         validatorFactories: validatorFactories,
         asyncValidatorFactories: asyncValidatorFactories,
         initialValue: initialValue,
+        valueConverter: intStringConverter,
       );
 
   /// Defines a new property with property value type [double] and
@@ -143,6 +144,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
         validatorFactories: validatorFactories,
         asyncValidatorFactories: asyncValidatorFactories,
         initialValue: initialValue,
+        valueConverter: doubleStringConverter,
       );
 
   /// Defines a new property with property value type [BigInt] and
@@ -160,6 +162,7 @@ extension FormCompanionPropertyDescriptorsBuilderExtension
         validatorFactories: validatorFactories,
         asyncValidatorFactories: asyncValidatorFactories,
         initialValue: initialValue,
+        valueConverter: bigIntStringConverter,
       );
 }
 

--- a/tool/dev_env/tool/tasks/enable_pub_get.dart
+++ b/tool/dev_env/tool/tasks/enable_pub_get.dart
@@ -12,6 +12,7 @@ Future<void> enablePubGetCore({required bool runPubGet}) async {
   final packages = await getPackages('../../packages').toList();
   for (final package in packages) {
     await _enablePubGetCore(
+      package,
       '../../packages/$package',
       packages,
       runPubGet: runPubGet,
@@ -26,28 +27,31 @@ Future<void> enablePubGetCore({required bool runPubGet}) async {
 }
 
 Future<void> _enablePubGetCore(
+  String package,
   String directory,
   List<String> packages, {
   bool runPubGet = false,
 }) async {
-  final pubspecFile = getFile('$directory/pubspec.yaml');
-  final yamlContent = await pubspecFile.readAsString();
-  final pubspec = Pubspec.parse(yamlContent);
-  final pubspecEditor = YamlEditor(yamlContent);
+  if (shouldEnablePubGetTargets(package)) {
+    final pubspecFile = getFile('$directory/pubspec.yaml');
+    final yamlContent = await pubspecFile.readAsString();
+    final pubspec = Pubspec.parse(yamlContent);
+    final pubspecEditor = YamlEditor(yamlContent);
 
-  final dependentPackages = findDependentPackages(
-    packages,
-    pubspec,
-  );
+    final dependentPackages = findDependentPackages(
+      packages,
+      pubspec,
+    );
 
-  _enableLocalPackageDepencendies(
-    dependentPackages.toList(),
-    pubspec,
-    pubspecEditor,
-  );
+    _enableLocalPackageDepencendies(
+      dependentPackages.toList(),
+      pubspec,
+      pubspecEditor,
+    );
 
-  await pubspecFile.writeAsString(pubspecEditor.toString());
-  log('`pub get` is enabled for `${path.canonicalize(pubspecFile.path)}`.');
+    await pubspecFile.writeAsString(pubspecEditor.toString());
+    log('`pub get` is enabled for `${path.canonicalize(pubspecFile.path)}`.');
+  }
 
   if (runPubGet) {
     await _runPubGet(directory);

--- a/tool/dev_env/tool/tasks/utils.dart
+++ b/tool/dev_env/tool/tasks/utils.dart
@@ -48,3 +48,8 @@ Iterable<String> findDependentPackages(
     }
   }
 }
+
+final _packagesShouldNotBeTweakedPubSpecs = {'form_companion_generator_test'};
+
+bool shouldEnablePubGetTargets(String package) =>
+    !_packagesShouldNotBeTweakedPubSpecs.contains(package);


### PR DESCRIPTION
Now, helper extension methods to add properties more readable as DSL.

Previous:

```dart
PropertyDescriptorsBuilder()
  ..addInt(...)
  ..addString<P>(...)
  ..addText(...)
```

Now:

```dart
PropertyDescriptorsBuilder()
  ..integerText(...) // more readable and suggests using TextField
  ..stringConvertible<P>(...) // more readable and suggests you should specify string converter
  ..string(...) // also more readble
```
