### PR TITLE
Support property parameter

### DIFF
--- a/doc/ideas.md
+++ b/doc/ideas.md
@@ -1,0 +1,188 @@
+# Ideas
+
+Some random ideas for future implementation.
+
+## Generator
+
+### L10N support
+
+Some form fields supports `label` and/or `hint` for display. These should be localized for usability, because many application users desire localized words rather than English words.
+
+The biggest problem is that there are some L10N frameworks and they do not specify predicatable format to generate data. For example, `intl` package specifies that writing `Intl.message(name: KEY, args: [...])` format, but `easy_localization` package specifies `KEY.tr()` format. So, we must introduce flexible way to enable specyfing as your desired format.
+
+We will introduce this as follows:
+
+* We introduce customizable properties in `build.yaml` and parameters of `@FormCompanion` annotation.
+  * We MAY omit some properties in `@FormCompanion` annotation for technical reasons.
+* We introduce macros (desribed bellow) in the customizable properties, which are replaced by some predefined values in emit time.
+
+#### Providing properties
+
+**property** | **default** | **description**
+--|--|--
+`labelTemplate` | `#PROPERTY_NAME#` | Template to be used for `label` parameter of `InputDecoration` constructor.
+`hintTemplate` | `null` | Template to be used for `hint` parameter of `InputDecoration` constructor.
+
+#### Example
+
+```dart
+@FormCompanion(
+  labelTemplate: 'l10n.#PROPERTY_NAME#_label.tr()',
+  hintTemplate: 'l10n.#PROPERTY_NAME#_hint.tr()',
+)
+```
+
+```yaml
+labelTemplate: 'l10n.#PROPERTY_NAME#_label.tr()'
+hintTemplate: 'l10n.#PROPERTY_NAME#_hint.tr()'
+```
+
+### DropdownItem and FormBuilderItem support
+
+After `form_companion_generator` used, many form field construction should become as follows:
+
+```dart
+final presenter = ...
+return Row(
+  rows: [
+    presenter.fields.id(context),
+    presenter.fields.name(context),
+    ActionButton(
+      submit: presenter.submit(context),
+    ),
+  ],
+);
+```
+
+However, for selective fields including `DropdownButtonFormField` or `FormBuilderFilterChip`, there are long code to specify option items specification as follows:
+
+```dart
+  presenter.fields.contry(items: [
+      DropdownItem(value: Country.japan, label: localizedCountryName.japan),
+      // we know there are over 100+ countries over the world, and it is hard to use for loop when we have to implement i18n/l10n, right?
+  ])
+```
+
+So, we will introduce template based item generation.
+
+#### Spec
+
+* For parameters which are `List<DropdownMenuItem<T>>` and `List<FormBuilderOption<T>>` types are supported.
+  * The list item types are specified in keys of `itemTemplates` property as described later.
+* The field value type (`F` of `PropertyDescriptor<P, F>`) must be enum.
+* We introduce customizable properties in `build.yaml` and parameters of `@FormCompanion` annotation.
+* Format is `itemTemplates` map which key is target element type like `DropdownItem` or `FormBuilderOption`, case sensitive.
+* We will support macros for itemTemplates.
+
+#### Customize in app code
+
+If the emitter emits item template based form factory code, it also emits `{propertyName}ItemFactory`, which type is `FormFieldOptionFactory<T, TOption>`.
+
+```dart
+typedef FormFieldOptionFactory<P, F, O> = O Function(PropertyDescriptor<P, F>, P);
+```
+
+For example, form factory for `DropdownButtonField` should be as follows:
+
+```dart
+DropdownButtonFormField myProperty(
+  BuildContext context, {
+  ...,
+  FormFieldOptionFactory<MyEnum, MyEnum, DropdownMenuItem<MyEnum>>? itemsItemFactory,
+  ...,
+  }) {
+    ...
+    return DropdownButtonFormField(
+      ...,
+      items: MyEnum.values.map((p => (itemsItemFactory ?? _defaultItemsItemFactory)(property, p)).toList(),
+      ...,
+    )
+  }
+
+  DropdownMenuItem<MyEnum> _defaultItemsItemFactory(PropertyDescriptorBuilder<MyEnum, MyEnum> property, MyEnum value)
+    => 
+    // Folloing code is generated from macro and code specified as itemTemplate.DropdownOption
+    DropdownMenuItem<MyEnum>(value: value, child: Text('${value}_label'.tr(),);
+)
+```
+
+#### Example of `itemTemplates`
+
+```dart
+@FormCompanion(itemTemplates: const {
+  'DropdownMenuItem': "DropdownMenuItem<MyEnum>(value: #ITEM_VALUE#, child: Text('\${#ITEM_VALUE#}_label'.tr(),)",
+})
+```
+
+```yaml
+itemTemplates:
+  'DropdownMenuItem': "DropdownMenuItem<MyEnum>(value: #ITEM_VALUE#, child: Text('${#ITEM_VALUE#}_label'.tr(),)"
+```
+
+### Extra imports
+
+Some template values requires additional import, so we supports extra imports properties.
+
+* We introduce customizable properties in `build.yaml` and parameters of `@FormCompanion` annotation.
+* Format is `extraImports` map which key is package uri (`package:` scheme) and its value is list of import type names.
+  * The value can be empty list.
+* We will not support macros for `extraImports`.
+
+#### Example of `extraImports`
+
+```dart
+@FormCompanion(extraImports: const {
+  'package:example/example.dart': [
+    'Something',
+    'Anything',
+  ],
+  'package:example/something.dart': [
+    'Foo',
+    'Bar',
+  ],
+})
+```
+
+```yaml
+extraImports:
+  'package:example/example.dart':
+    - Something
+    - Anything
+  'package:example/something.dart':
+    - Foo
+    - Bar
+```
+
+### Macros
+
+#### Syntax
+
+In regex format, macro key must be as follows:
+
+```regex
+#[A-Z]+(_[A-Z]+)*#
+```
+
+In each template, macro key must be surrounded with '#' as follows:
+
+```yaml
+"Text('${#ITEM_VALUE#}_label'.tr()"
+```
+
+This should be translated as following dart expression (`value` is subject to change):
+
+```dart
+Text('${value}_label'.tr())
+```
+
+#### Lists
+
+**key** | **available in** | **description**
+--|--
+`PROPERTY_NAME` | any | Replaced with static token which is name of the property.
+`PROPERTY_VALUE_TYPE` | any | Replaced with static token which is `P` of `PropertyDescriptor<P, F>` for the property.
+`FIELD_VALUE_TYPE` | any | Replaced with static token which is `P` of `PropertyDescriptor<P, F>` for the property.
+`PROPERTY` | any | Replaced with static token which is local variable identifier of `PropertyDescriptor<P, F>` for the property.
+`LABEL_TEMPLATE` | `itemTemplates` | Replaced with expression resolved for `labelTemplate`.
+`HINT_TEMPLATE` | `itemTemplates` | Replaced with expression resolved for `hintTemplate`.
+`ITEM_VALUE` | `itemTemplates` | Replaced with static token which is local variable identifier of current enum value.

--- a/packages/form_companion_generator/lib/src/emitter/field_factory.dart
+++ b/packages/form_companion_generator/lib/src/emitter/field_factory.dart
@@ -3,6 +3,8 @@
 part of '../emitter.dart';
 
 const _presenterField = '_presenter';
+const _defaultPropertyDescriptorVariable = 'property';
+const _alternativePropertyDescriptorVariable = 'property_';
 
 /// Emits field factories and their holders.
 @visibleForTesting
@@ -197,14 +199,18 @@ Iterable<String> _emitFieldFactoryCore(
   for (final parameter in argumentHandler.callerSuppliableParameters) {
     yield '    ${emitParameter(instantiationContext, parameter)},';
   }
+  final propertyDescriptorVariable = argumentHandler.callerSuppliableParameters
+          .any((p) => p.name == _defaultPropertyDescriptorVariable)
+      ? _alternativePropertyDescriptorVariable
+      : _defaultPropertyDescriptorVariable;
   yield '  }) {';
-  yield '    final property = $_presenterField.${property.name};';
+  yield '    final $propertyDescriptorVariable = $_presenterField.${property.name};';
   yield '    return $constructorName(';
   yield* argumentHandler.emitAssignments(
     data: data,
     buildContext: 'context',
     presenter: _presenterField,
-    propertyDescriptor: 'property',
+    propertyDescriptor: propertyDescriptorVariable,
     indent: '      ',
   );
   yield '    );';

--- a/packages/form_companion_generator/test/emitter_test.dart
+++ b/packages/form_companion_generator/test/emitter_test.dart
@@ -35,10 +35,7 @@ typedef NamedFactorySpec = Tuple3<String?, String, List<FactoryParameterSpec>>;
 
 const emptyConfig = Config(<String, dynamic>{});
 
-// TODO(yfakariya): DropdownItems support w/ label template
-// labelTemplate:
-//    @FormCompanion(labelTemplate: 'L.\${property}_label.tr()', hintTemplate: 'L.\${property}_hint.tr()')
-// \$(\{(<ID>?[_A-Za-z$][_A-Za-z0-9$]*)\}|(<ID>?[_A-Za-z][_A-Za-z0-9]*))
+// TODO(yfakariya): DropdownItems support w/ label template: see /doc/ideas.md
 
 Future<void> main() async {
   final logger = Logger('emitter_test');

--- a/packages/form_companion_generator/test/emitter_test.dart
+++ b/packages/form_companion_generator/test/emitter_test.dart
@@ -1042,7 +1042,7 @@ extension \$TestFieldFactoryExtension on Test {
   });
 
   group('emitFieldFactory', () {
-    FutureOr<void> _testEmitFieldFactory({
+    FutureOr<void> testEmitFieldFactory({
       required bool isFormBuilder,
       required InterfaceType propertyValueType,
       required InterfaceType fieldValueType,
@@ -1114,7 +1114,7 @@ extension \$TestFieldFactoryExtension on Test {
       ]) {
         test(
           'String with ${warnings.length} warnings',
-          () => _testEmitFieldFactory(
+          () => testEmitFieldFactory(
             isFormBuilder: false,
             propertyValueType: library.typeProvider.stringType,
             fieldValueType: library.typeProvider.stringType,
@@ -1130,7 +1130,7 @@ extension \$TestFieldFactoryExtension on Test {
         final type = isEnum ? myEnumType : library.typeProvider.boolType;
         test(
           isEnum ? 'enum' : 'bool',
-          () => _testEmitFieldFactory(
+          () => testEmitFieldFactory(
             isFormBuilder: false,
             propertyValueType: type,
             fieldValueType: type,
@@ -1142,7 +1142,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'String with known preferredFieldType -- preferredFieldType is used',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: false,
           propertyValueType: library.typeProvider.stringType,
           fieldValueType: library.typeProvider.stringType,
@@ -1158,7 +1158,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'bool with known preferredFieldType -- preferredFieldType is used',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: false,
           propertyValueType: library.typeProvider.intType,
           fieldValueType: library.typeProvider.intType,
@@ -1174,7 +1174,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'Unknown preferredFieldType -- error',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: false,
           propertyValueType: library.typeProvider.stringType,
           fieldValueType: library.typeProvider.stringType,
@@ -1188,7 +1188,7 @@ extension \$TestFieldFactoryExtension on Test {
       for (final value in [true, false]) {
         test(
           'doAutovalidate ($value) is respected',
-          () => _testEmitFieldFactory(
+          () => testEmitFieldFactory(
             isFormBuilder: false,
             propertyValueType: library.typeProvider.stringType,
             fieldValueType: library.typeProvider.stringType,
@@ -1208,7 +1208,7 @@ extension \$TestFieldFactoryExtension on Test {
       ]) {
         test(
           'String with ${warnings.length} warnings',
-          () => _testEmitFieldFactory(
+          () => testEmitFieldFactory(
             isFormBuilder: true,
             propertyValueType: library.typeProvider.stringType,
             fieldValueType: library.typeProvider.stringType,
@@ -1221,7 +1221,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'enum',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: true,
           propertyValueType: myEnumType,
           fieldValueType: myEnumType,
@@ -1232,7 +1232,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'bool',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: true,
           propertyValueType: library.typeProvider.boolType,
           fieldValueType: library.typeProvider.boolType,
@@ -1243,7 +1243,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'DateTime',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: true,
           propertyValueType: dateTimeType,
           fieldValueType: dateTimeType,
@@ -1254,7 +1254,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'DateTimeRange',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: true,
           propertyValueType: dateTimeRangeType,
           fieldValueType: dateTimeRangeType,
@@ -1265,7 +1265,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'RangeValue',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: true,
           propertyValueType: rangeValuesType,
           fieldValueType: rangeValuesType,
@@ -1276,7 +1276,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'String with known preferredFieldType -- preferredFieldType is used',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: true,
           propertyValueType: library.typeProvider.stringType,
           fieldValueType: library.typeProvider.stringType,
@@ -1292,7 +1292,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'bool with known preferredFieldType -- preferredFieldType is used',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: true,
           propertyValueType: library.typeProvider.boolType,
           fieldValueType: library.typeProvider.stringType,
@@ -1319,7 +1319,7 @@ extension \$TestFieldFactoryExtension on Test {
       ]) {
         test(
           'preferredFieldType of ${spec.name} for bool',
-          () => _testEmitFieldFactory(
+          () => testEmitFieldFactory(
             isFormBuilder: true,
             propertyValueType: spec.type,
             fieldValueType: spec.type,
@@ -1348,7 +1348,7 @@ extension \$TestFieldFactoryExtension on Test {
       ]) {
         test(
           'preferredFieldType of ${spec.name} for numeric',
-          () => _testEmitFieldFactory(
+          () => testEmitFieldFactory(
             isFormBuilder: true,
             propertyValueType: spec.type,
             fieldValueType: spec.type,
@@ -1393,7 +1393,7 @@ extension \$TestFieldFactoryExtension on Test {
       ]) {
         test(
           'preferredFieldType of ${spec.name} for enum',
-          () => _testEmitFieldFactory(
+          () => testEmitFieldFactory(
             isFormBuilder: true,
             propertyValueType: spec.type,
             fieldValueType: spec.type,
@@ -1410,7 +1410,7 @@ extension \$TestFieldFactoryExtension on Test {
 
       test(
         'String with unknown preferredFieldType -- error',
-        () => _testEmitFieldFactory(
+        () => testEmitFieldFactory(
           isFormBuilder: true,
           propertyValueType: library.typeProvider.stringType,
           fieldValueType: library.typeProvider.stringType,
@@ -1426,7 +1426,7 @@ extension \$TestFieldFactoryExtension on Test {
       for (final value in [true, false]) {
         test(
           'doAutovalidate ($value) is respected',
-          () => _testEmitFieldFactory(
+          () => testEmitFieldFactory(
             isFormBuilder: true,
             propertyValueType: library.typeProvider.stringType,
             fieldValueType: library.typeProvider.stringType,

--- a/packages/form_companion_generator/test/emitter_test.dart
+++ b/packages/form_companion_generator/test/emitter_test.dart
@@ -75,6 +75,8 @@ Future<void> main() async {
   final formBuilderSwitch = await lookupFormBuilderClass('FormBuilderSwitch');
   final formBuilderTextField =
       await lookupFormBuilderClass('FormBuilderTextField');
+  final formFieldWithPropertyParameter =
+      library.getType('FormFieldWithPropertyParameter')!;
 
   final parametersLibrary = await getParametersLibrary();
 
@@ -1434,6 +1436,38 @@ extension \$TestFieldFactoryExtension on Test {
           ),
         );
       }
+    });
+
+    group('special cases', () {
+      test(
+        'parameter has property -- local variable changed to property_',
+        () => testEmitFieldFactory(
+          isFormBuilder: false,
+          propertyValueType: library.typeProvider.stringType,
+          fieldValueType: library.typeProvider.stringType,
+          formFieldClass: formFieldWithPropertyParameter,
+          warnings: [],
+          expectedBody: '''
+  /// Gets a [FormField] for `prop` property.
+  FormFieldWithPropertyParameter prop(
+    BuildContext context, {
+    InputDecoration? decoration,
+    String? property,
+  }) {
+    final property_ = _presenter.prop;
+    return FormFieldWithPropertyParameter(
+      key: _presenter.getKey(property_.name, context),
+      initialValue: property_.getFieldValue(Localizations.maybeLocaleOf(context) ?? const Locale('en', 'US')),
+      decoration: decoration ?? const InputDecoration().copyWith(
+        labelText: property_.name,
+      ),
+      onSaved: (v) => property_.setFieldValue(v, Localizations.maybeLocaleOf(context) ?? const Locale('en', 'US')),
+      validator: property_.getValidator(context),
+      property: property,
+    );
+  }''',
+        ),
+      );
     });
   });
 

--- a/packages/form_companion_generator_test/lib/form_fields.dart
+++ b/packages/form_companion_generator_test/lib/form_fields.dart
@@ -36,3 +36,21 @@ const Type myEnum = MyEnum;
 typedef _StringComparison = int Function(String, String);
 
 const Type stringComparison = _StringComparison;
+
+class FormFieldWithPropertyParameter extends TextFormField {
+  FormFieldWithPropertyParameter({
+    Key? key,
+    String? initialValue,
+    InputDecoration? decoration = const InputDecoration(),
+    FormFieldSetter<String>? onSaved,
+    FormFieldValidator<String>? validator,
+    // ignore: avoid_unused_constructor_parameters
+    String? property,
+  }) : super(
+          key: key,
+          initialValue: initialValue,
+          decoration: decoration,
+          onSaved: onSaved,
+          validator: validator,
+        );
+}


### PR DESCRIPTION
Support `FormField<T>` classes which have a parameter named `property`.
Note that parameters which have both of `property` and `property_` parameters because it is extremely rare.