### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,17 @@ name: ci
 
 on:
   push:
-    paths:
-      - '**.dart'
-      - 'pubspec.*'
-      - 'analysis_options.yaml'
-      - '.github/workflows/*.yml'
-      - '.github/actions/**/*.yml'
+    branches:
+      - master
+      - main
+    paths-ignore:
+      - '**.md'
   pull_request:
-    paths:
-      - '**.dart'
-      - 'pubspec.*'
-      - 'analysis_options.yaml'
-      - '.github/workflows/*.yml'
-      - '.github/actions/**/*.yml'
+    paths-ignore:
+      - '**.md'
+  schedule:
+    # everyday at 09:00 (UTC) 
+    - cron: "0 9 * * *"
 
 jobs:
   build-latest:


### PR DESCRIPTION
* Set a scheduled task to detect dependent patches and their incompatibilities.
* Change paths to paths-ignore to follow new file formats automatically.
* Restrict push trigger to master/main branches to prevent duplicated execution on PR.